### PR TITLE
Add OpenRouter provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ topic_tree:
   topic_prompt: "Python programming fundamentals and best practices"
 
   # LLM Settings
-  provider: "ollama"                    # Options: openai, anthropic, gemini, ollama
+  provider: "ollama"                    # Options: openai, anthropic, gemini, ollama, openrouter
   model: "qwen3:0.6b"                    # Change to your preferred model
   temperature: 0.7                      # 0.0 = deterministic, 1.0 = creative
 

--- a/deepfabric/config.py
+++ b/deepfabric/config.py
@@ -31,7 +31,7 @@ class TopicTreeConfig(BaseModel):
     provider: str = Field(
         default=DEFAULT_PROVIDER,
         min_length=1,
-        description="LLM provider (openai, anthropic, gemini, ollama)",
+        description="LLM provider (openai, anthropic, gemini, ollama, openrouter)",
     )
     model: str = Field(
         default=DEFAULT_MODEL,
@@ -71,7 +71,7 @@ class TopicGraphConfig(BaseModel):
     provider: str = Field(
         default=DEFAULT_PROVIDER,
         min_length=1,
-        description="LLM provider (openai, anthropic, gemini, ollama)",
+        description="LLM provider (openai, anthropic, gemini, ollama, openrouter)",
     )
     model: str = Field(
         default=DEFAULT_MODEL,
@@ -99,7 +99,7 @@ class DataEngineConfig(BaseModel):
     provider: str = Field(
         default=DEFAULT_PROVIDER,
         min_length=1,
-        description="LLM provider (openai, anthropic, gemini, ollama)",
+        description="LLM provider (openai, anthropic, gemini, ollama, openrouter)",
     )
     model: str = Field(
         default=DEFAULT_MODEL,

--- a/deepfabric/generator.py
+++ b/deepfabric/generator.py
@@ -56,7 +56,7 @@ class DataSetGeneratorConfig(BaseModel):
         description="System prompt that goes into the final dataset (falls back to generation_system_prompt if not provided)",
     )
     provider: str = Field(
-        ..., min_length=1, description="LLM provider (openai, anthropic, gemini, ollama)"
+        ..., min_length=1, description="LLM provider (openai, anthropic, gemini, ollama, openrouter)"
     )
     model_name: str = Field(..., min_length=1, description="Name of the model to use")
     prompt_template: str | None = Field(default=None, description="Custom prompt template")

--- a/deepfabric/graph.py
+++ b/deepfabric/graph.py
@@ -42,7 +42,7 @@ class GraphConfig(BaseModel):
     provider: str = Field(
         default="ollama",
         min_length=1,
-        description="LLM provider (openai, anthropic, gemini, ollama)",
+        description="LLM provider (openai, anthropic, gemini, ollama, openrouter)",
     )
     model_name: str = Field(
         default=TOPIC_GRAPH_DEFAULT_MODEL,

--- a/deepfabric/llm/client.py
+++ b/deepfabric/llm/client.py
@@ -36,7 +36,7 @@ def make_outlines_model(provider: str, model_name: str, **kwargs) -> Any:
     """Create an Outlines model for the specified provider and model.
 
     Args:
-        provider: Provider name (openai, anthropic, gemini, ollama)
+        provider: Provider name (openai, anthropic, gemini, ollama, openrouter)
         model_name: Model identifier
         **kwargs: Additional parameters passed to the client
 
@@ -75,6 +75,33 @@ def make_outlines_model(provider: str, model_name: str, **kwargs) -> Any:
 
             client = genai.Client(api_key=api_key)
             return outlines.from_gemini(client, model_name, **kwargs)
+
+        if provider == "openrouter":
+            api_key = os.getenv("OPENROUTER_API_KEY")
+            if not api_key:
+                _raise_api_key_error("OPENROUTER_API_KEY")
+
+            base_url = kwargs.get("base_url", "https://openrouter.ai/api/v1")
+            client_kwargs = {
+                k: v for k, v in kwargs.items() if k not in {"base_url", "default_headers"}
+            }
+
+            default_headers = kwargs.get("default_headers")
+            if default_headers is None:
+                referer = os.getenv("OPENROUTER_HTTP_REFERER")
+                title = os.getenv("OPENROUTER_APP_TITLE")
+                inferred_headers = {}
+                if referer:
+                    inferred_headers["HTTP-Referer"] = referer
+                if title:
+                    inferred_headers["X-Title"] = title
+                if inferred_headers:
+                    client_kwargs["default_headers"] = inferred_headers
+            else:
+                client_kwargs["default_headers"] = default_headers
+
+            client = openai.OpenAI(api_key=api_key, base_url=base_url, **client_kwargs)
+            return outlines.from_openai(client, model_name)
 
         if provider == "ollama":
             # Use OpenAI-compatible endpoint for Ollama

--- a/deepfabric/llm/errors.py
+++ b/deepfabric/llm/errors.py
@@ -96,7 +96,7 @@ def handle_gemini_error(e: Exception, provider: str, model_name: str) -> DataSet
 
 def handle_provider_error(e: Exception, provider: str, model_name: str) -> DataSetGeneratorError:
     """Handle errors for any provider with appropriate error handler."""
-    if provider in ["openai", "ollama"]:
+    if provider in ["openai", "ollama", "openrouter"]:
         return handle_openai_error(e, provider, model_name)
     if provider == "anthropic":
         return handle_anthropic_error(e, provider, model_name)

--- a/deepfabric/tree.py
+++ b/deepfabric/tree.py
@@ -61,7 +61,7 @@ class TreeConfig(BaseModel):
     provider: str = Field(
         default="ollama",
         min_length=1,
-        description="LLM provider (openai, anthropic, gemini, ollama)",
+        description="LLM provider (openai, anthropic, gemini, ollama, openrouter)",
     )
     model_name: str = Field(
         default=TOPIC_TREE_DEFAULT_MODEL,

--- a/docs/guide/provider-integration.md
+++ b/docs/guide/provider-integration.md
@@ -12,6 +12,8 @@ DeepFabric supports all model providers through consistent configuration pattern
 
 **Anthropic** offers Claude models with strong reasoning capabilities and detailed response generation.
 
+**OpenRouter** aggregates multiple frontier and open-source models behind a unified OpenAI-compatible API endpoint with flexible routing controls.
+
 **Google** includes Gemini models with multimodal capabilities and competitive performance characteristics.
 
 **Ollama** enables local model execution with privacy benefits and no per-token costs.
@@ -33,6 +35,11 @@ export ANTHROPIC_API_KEY="your-anthropic-key"
 
 # Google Gemini authentication
 export GEMINI_API_KEY="your-gemini-key"
+
+# OpenRouter authentication (plus optional headers)
+export OPENROUTER_API_KEY="your-openrouter-key"
+export OPENROUTER_HTTP_REFERER="https://your-app-domain"      # optional but recommended
+export OPENROUTER_APP_TITLE="DeepFabric Dataset Generator"    # optional but recommended
 
 # Hugging Face (for dataset upload)
 export HF_TOKEN="your-hf-token"
@@ -56,6 +63,10 @@ model: "claude-3-opus"
 # Local Ollama
 provider: "ollama"
 model: "mistral:latest"
+
+# OpenRouter (any OpenAI-compatible model string)
+provider: "openrouter"
+model: "anthropic/claude-3.5-sonnet"
 
 # Google Gemini
 provider: "gemini"

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -10,7 +10,7 @@ topic_tree:
   topic_prompt: "Python programming fundamentals and best practices"
 
   # LLM Settings
-  provider: "openai"                    # Options: openai, anthropic, gemini, ollama
+  provider: "openai"                    # Options: openai, anthropic, gemini, ollama, openrouter
   model: "gpt-4o"                   # Change to your preferred model
   temperature: 0.7                      # 0.0 = deterministic, 1.0 = creative
 
@@ -30,7 +30,7 @@ data_engine:
   instructions: "Create clear programming tutorials with working code examples and explanations"
 
   # LLM Settings (can override main provider/model)
-  provider: "openai"                    # Options: openai, anthropic, gemini, ollama
+  provider: "openai"                    # Options: openai, anthropic, gemini, ollama, openrouter
   model: "gpt-4o"   
   temperature: 0.3                      # Lower temperature for more consistent code
   max_retries: 3                        # Number of retries for failed generations

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -14,7 +14,7 @@ dataset_system_prompt: |
 # Topic generation settings
 topic_tree:
   topic_prompt: "Vehicle mechanics and advancements"  # Change this to your domain
-  provider: "gemini"  # or "anthropic", "gemini", "ollama"
+  provider: "gemini"  # or "anthropic", "gemini", "ollama", "openrouter"
   model: "gemini-2.5-flash-lite"  # Cost-effective model
   temperature: 0.8
   degree: 4  # Number of subtopics per branch

--- a/examples/unsloth_grpo_config.yaml
+++ b/examples/unsloth_grpo_config.yaml
@@ -16,7 +16,7 @@ dataset_system_prompt: |
 topic_tree:
   topic_prompt: "Mathematical problems, logical puzzles, and analytical reasoning tasks"
   topic_system_prompt: "Generate problems that require step-by-step reasoning to solve"
-  provider: "gemini"  # or "anthropic", "gemini", "ollama"
+  provider: "gemini"  # or "anthropic", "gemini", "ollama", "openrouter"
   model: "gemini-2.5-flash-lite"
   temperature: 0.8
   degree: 3

--- a/examples/unsloth_instruct_config.yaml
+++ b/examples/unsloth_instruct_config.yaml
@@ -13,7 +13,7 @@ dataset_system_prompt: |
 topic_tree:
   topic_prompt: "Programming languages, algorithms, and software engineering best practices"
   topic_system_prompt: "Generate diverse programming topics covering fundamentals to advanced concepts"
-  provider: "openai"  # Options: "openai", "anthropic", "gemini", "ollama"
+  provider: "openai"  # Options: "openai", "anthropic", "gemini", "ollama", "openrouter"
   model: "gpt-4o-mini"  # Cost-effective model for topic generation
   temperature: 0.8  # Higher temperature for diverse topic generation
   degree: 3  # Number of subtopics per node


### PR DESCRIPTION
## Summary
- add OpenRouter as a supported provider in the LLM client, including API key handling and optional default headers
- update provider metadata descriptions, examples, and docs to list OpenRouter as an available option

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68d8418d928883269ffc5369d83b645f